### PR TITLE
過去ログも含めて送れるように修正

### DIFF
--- a/backend/chatapi.py
+++ b/backend/chatapi.py
@@ -14,11 +14,14 @@ def encode_image(image_path):
         return base64.b64encode(image_file.read()).decode("utf-8")
     
 # メインの関数
-# text: 入力に使うテキスト（音声で取得した部分）
+# input_messages: 過去の履歴も含めたユーザーの入力メッセージ 
 # base64_image: スクショ画像をbase64エンコードしたもの
 # max_tokens: 生成するテキストの最大トークン数
-def chatapi(input_text, base64_image = None, max_tokens = 300):
-   # OpenAI APIのクライアントを作成する.
+def chatapi(input_messages, base64_image = None, max_tokens = 300):
+    # テスト用
+    print("バックエンドで受け取ったinput_messages:", input_messages)
+    
+    # OpenAI APIのクライアントを作成する.
     client = OpenAI(
         api_key=os.getenv("OPENAI_API_KEY"),
     )
@@ -28,16 +31,7 @@ def chatapi(input_text, base64_image = None, max_tokens = 300):
         # print("テキストだけでapiを叩きます")
         response = client.chat.completions.create(
             model="gpt-4o-mini",
-            messages=[
-                {
-                    "role": "system",
-                    "content": "あなたは優秀なAIアシスタントです。できるだけ簡潔に、わかりやすく、正確に回答してください。回答は口頭で説明したい部分とテキストで説明したい部分に分けて、その区切りは「ここからテキスト説明部分に変わります。」という文字列で行ってください。${max_tokens}トークン以内で回答してください。また、テキストで説明するよ、という旨を口頭で説明する部分に入れてください。",
-                },
-                {
-                    "role": "user",
-                    "content": input_text,
-                }
-            ],
+            messages=input_messages,
             max_tokens=max_tokens,
         )
     else:
@@ -45,47 +39,38 @@ def chatapi(input_text, base64_image = None, max_tokens = 300):
         # print("テキスト+画像でapiを叩きます")
         response = client.chat.completions.create(
             model="gpt-4o-mini",
-            messages=[
-                {
-                    "role": "system",
-                    "content": "あなたは優秀なAIアシスタントです。できるだけ簡潔に、わかりやすく、正確に回答してください。回答は口頭で説明したい部分とテキストで説明したい部分に分けて、その区切りは「ここからテキスト説明部分に変わります。」という文字列で行ってください。${max_tokens}トークン以内で回答してください。また、テキストで説明するよ、という旨を口頭で説明する部分に入れてください。",
-                },
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": input_text},  # ここに質問を書く
-                        {"type": "image_url", "image_url":{"url": f"data:image/jpeg;base64,{base64_image}"}},  # 画像の指定の仕方がちょい複雑
-                    ],
-                }
-            ],
+            messages=input_messages,
             max_tokens=max_tokens,
         )
     
     # print(response)
     return response
 
+def main():
+    # 画像のパス
+    image_path = "image/codeimage.png"
 
-# 画像のパス
-image_path = "image/codeimage.png"
+    # 画像をbase64にエンコードする
+    base64_image = encode_image(image_path)
 
-# 画像をbase64にエンコードする
-base64_image = encode_image(image_path)
+    # チャットの応答を生成する
+    response = chatapi("この画面の下の方に映っているエラーの原因を教えて下さい。", base64_image, 1000)
+    answer = response.choices[0].message.content
+    print(answer)
 
-# チャットの応答を生成する
-response = chatapi("この画面の下の方に映っているエラーの原因を教えて下さい。", base64_image, 1000)
-answer = response.choices[0].message.content
-print(answer)
+    # 区切り文字列
+    separator = "ここからテキスト説明部分に変わります"
 
-# 区切り文字列
-separator = "ここからテキスト説明部分に変わります"
+    # 区切り文字で分割
+    if separator in answer:
+        speech_part, text_part = answer.split(separator, 1)
+    else:
+        speech_part, text_part = answer, ""  # 区切りがない場合
+        
+    print("Speech Part:")
+    print(speech_part.strip())  # 前後の空白を削除して整形
+    print("\nText Part:")
+    print(text_part.strip())
 
-# 区切り文字で分割
-if separator in answer:
-    speech_part, text_part = answer.split(separator, 1)
-else:
-    speech_part, text_part = answer, ""  # 区切りがない場合
-    
-print("Speech Part:")
-print(speech_part.strip())  # 前後の空白を削除して整形
-print("\nText Part:")
-print(text_part.strip())
+if __name__ == "__main__":
+    main()

--- a/backend/chatapi.py
+++ b/backend/chatapi.py
@@ -2,9 +2,6 @@ import base64
 from dotenv import load_dotenv
 from openai import OpenAI
 import os
-import sys
-print(sys.executable)
-
 
 load_dotenv()
 
@@ -20,6 +17,13 @@ def encode_image(image_path):
 def chatapi(input_messages, base64_image = None, max_tokens = 300):
     # テスト用
     print("バックエンドで受け取ったinput_messages:", input_messages)
+    
+    # 新しいメッセージを先頭に追加
+    system_message = {
+        "role": "user",
+        "content": "あなたは優秀なAIアシスタントです。できるだけ簡潔に、わかりやすく、正確に回答してください。基本的に回答は口頭で説明してほしいのですが、もしテキストで表示したほうが良いような内容（ソースコードなど）がある場合は、口頭で説明したい部分とテキストで説明したい部分に分けて、その区切りは「ここからテキスト説明部分に変わります。」という文字列で行ってください。${max_tokens}トークン以内で回答してください。また、テキストで説明するよ、という旨を口頭で説明する部分に入れてください。"
+    }
+    input_messages.insert(0, system_message)
     
     # OpenAI APIのクライアントを作成する.
     client = OpenAI(

--- a/backend/chatapi.py
+++ b/backend/chatapi.py
@@ -1,7 +1,7 @@
 import base64
 from dotenv import load_dotenv
 from openai import OpenAI
-import  os
+import os
 import sys
 print(sys.executable)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,7 +58,7 @@ def use_chatapi(request: ChatRequest):
         # text-to-speechの処理を追加
         speech_part_base64 = text_to_speech_base64(speech_part)
         
-        return {"text_part": text_part, "speech_part": speech_part_base64}
+        return {"text_part": text_part, "speech_part_script": speech_part, "speech_part_base64": speech_part_base64}
     except Exception as e:
         error_message = format_exc()  # 詳細なスタックトレースを取得
         print(f"Error occurred: {error_message}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel 
 from starlette.middleware.cors import CORSMiddleware
-from typing import Optional
+from typing import Optional, List
 from traceback import format_exc
 
 # 自作関数のインポート
@@ -21,10 +21,13 @@ app.add_middleware(
     allow_headers=["*"]       # 追記により追加
 )
 
+class Message(BaseModel):
+    role: str
+    content: str
 
 # リクエストボディのデータ構造を定義
 class ChatRequest(BaseModel):
-    input_text: str
+    input_messages: List[Message]
     base64_image: Optional[str] = None
     max_tokens: int = 300
     
@@ -42,7 +45,7 @@ def use_chatapi(request: ChatRequest):
     try:
         # リクエストボディから値を取得してchatapiに渡す
         response = chatapi(
-            input_text=request.input_text, 
+            input_messages=request.input_messages, 
             base64_image=request.base64_image, 
             max_tokens=request.max_tokens
         )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,12 +18,14 @@ function App() {
   ];
 
   // chatをstateとして管理
-  const [chat, setChat] = useState<string[]>([
-    "ずんだもん: こんにちは！",
+  const [chat, setChat] = useState<string[][]>([
+    ['assistant', 'こんにちは！なにかお手伝いできることはありますか？'],
+    ['user', 'こんにちは！'],
   ]);
 
   const handleUploadResult = (speech: string, message: string) => {
-    setChat((prevChat) => [...prevChat, `ずんだもん: ${message}`]);
+    // chatAPIの回答をchatに追加
+    setChat((prevChat) => [...prevChat, ['assistant', message]]);
     // Base64エンコードされたMP3を再生する処理
     playAudioFromBase64(speech);
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
   // chatをstateとして管理
   const [chat, setChat] = useState<string[][]>([
     ['assistant', 'こんにちは！なにかお手伝いできることはありますか？'],
-    ['user', 'こんにちは！'],
+    ['user', 'こんにちは！あなたはカレー作りの名人です。それを踏まえてこれからの回答に答えてください。'],
   ]);
 
   const handleUploadResult = (speech: string, message: string) => {
@@ -53,7 +53,7 @@ function App() {
     <Box>
       <Title title={title} />
       <Description description={description} />
-      <UploadDataButton callbackUploadResult={handleUploadResult} />
+      <UploadDataButton callbackUploadResult={handleUploadResult} chat={chat} />
       <ChatBox chat={chat} />
     </Box>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,11 +23,12 @@ function App() {
     ['user', 'こんにちは！あなたはカレー作りの名人です。それを踏まえてこれからの回答に答えてください。'],
   ]);
 
-  const handleUploadResult = (speech: string, message: string) => {
+  const handleUploadResult = (speechScript: string, speechBase64: string, answer: string) => {
     // chatAPIの回答をchatに追加
-    setChat((prevChat) => [...prevChat, ['assistant', message]]);
+    if(speechScript) setChat((prevChat) => [...prevChat, ['assistant', speechScript]]);
+    if(answer) setChat((prevChat) => [...prevChat, ['assistant', answer]]);
     // Base64エンコードされたMP3を再生する処理
-    playAudioFromBase64(speech);
+    playAudioFromBase64(speechBase64);
   };
 
   // Base64エンコードされたMP3を再生する関数

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -51,7 +51,7 @@ export default function ChatBox({ chat }: { chat: string[][] }) {
                         boxShadow: '0px 1px 3px rgba(0,0,0,0.1)',
                     }}
                 >
-                    <Box sx={{ textAlign: message[0] === 'user' ? 'left' : 'right' }}>
+                    <Box sx={{ textAlign: 'left' }}>
                         <ReactMarkdown>
                             {message[1]}
                         </ReactMarkdown>

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -2,7 +2,7 @@ import { Typography, Box } from "@mui/material";
 import { useEffect, useRef } from "react";
 import ReactMarkdown from 'react-markdown';
 
-export default function ChatBox({ chat }: { chat: string[] }) {
+export default function ChatBox({ chat }: { chat: string[][] }) {
     const chatBoxRef = useRef<HTMLDivElement>(null);
 
     // チャットが更新されるたびに一番下までスクロールするための処理
@@ -30,37 +30,34 @@ export default function ChatBox({ chat }: { chat: string[] }) {
                     回答テキスト
                 </Typography>
             </Box>
-            {chat.map((chat, index) => (
+            {chat.map((message, index) => (
                 <Box 
-                    key={index}
+                key={index}
+                sx={{
+                    display: 'flex',
+                    justifyContent: message[0] === 'user' ? 'flex-end' : 'flex-start', // 吹き出しの配置を切り替え
+                    margin: '8px 16px',
+                }}
+            >
+                <Box
                     sx={{
-                        display: 'flex',
-                        justifyContent: 'flex-start',
-                        margin: '8px 16px',
+                        padding: '8px 16px',
+                        backgroundColor: message[0] === 'user' ? '#f1f0f0' : '#e0f7fa', // 配色を変更
+                        borderRadius: message[0] === 'user' 
+                            ? '15px 15px 0 15px' 
+                            : '15px 15px 15px 0', // 吹き出しの形状を変える
+                        maxWidth: '80%', // 幅を制限
+                        wordWrap: 'break-word',
+                        boxShadow: '0px 1px 3px rgba(0,0,0,0.1)',
                     }}
                 >
-                    <Box
-                        sx={{
-                            padding: '8px 16px',
-                            backgroundColor: '#f1f0f0',
-                            borderRadius: '15px 15px 15px 0', // 吹き出しの形状
-                            maxWidth: '80%', // 幅を制限
-                            wordWrap: 'break-word',
-                            boxShadow: '0px 1px 3px rgba(0,0,0,0.1)',
-                        }}
-                    >
-                        {/* <Typography variant="body1" sx={{ textAlign: 'left' }}>
-                            <ReactMarkdown>
-                                {chat}
-                            </ReactMarkdown>
-                        </Typography> */}
-                        <Box sx={{ textAlign: 'left' }}>
+                    <Box sx={{ textAlign: message[0] === 'user' ? 'left' : 'right' }}>
                         <ReactMarkdown>
-                            {chat}
+                            {message[1]}
                         </ReactMarkdown>
-                        </Box>
                     </Box>
                 </Box>
+            </Box>
             ))}
         </Box>
     );

--- a/src/components/UploadDataButton.tsx
+++ b/src/components/UploadDataButton.tsx
@@ -24,10 +24,6 @@ const UploadDataButton: React.FC<UploadDataButtonProps> = ({callbackUploadResult
   // 録音停止時にファイルを保存するためのコールバック
   const handleAudioStop = (text: string) => {
     setSpeechText(text);
-    console.log('speechTextがセットされました');
-    chat.push(['user', text]);
-    console.log('chatにspeechTextが追加されました');
-    console.log('chat:', chat);
   };
 
   // スクリーンショット取得時に画像データを保存するためのコールバック
@@ -49,6 +45,8 @@ const UploadDataButton: React.FC<UploadDataButtonProps> = ({callbackUploadResult
   // APIに音声ファイルと画像を送信する関数
   const uploadData = async () => {
     try {
+      chat.push(['user', speechText || '']); // チャットデータに音声認識結果を追加
+      
       // チャットデータをAPIに送信する形式に変換
       const chat_converted = convertToMessageObjects(chat);
       console.log('chat_converted:', chat_converted);


### PR DESCRIPTION
apiで送る/受け取るbodyの設計を変更し、過去ログを含めた一連のメッセージをchatAPIに送れるように改善した。
src/components/UploadDataButton.tsx内のMAX_MESSAGE_LENGTHという定数で、最新から何個前のデータまで送るかを指定している。